### PR TITLE
Case sensitivity + missing pow()

### DIFF
--- a/src/veml6040.cpp
+++ b/src/veml6040.cpp
@@ -25,7 +25,10 @@ SOFTWARE.
 */
 
 #include "Wire.h"
-#include "VEML6040.h"
+#ifndef __MATH_H
+#include <math.h>
+#endif
+#include "veml6040.h"
 
 
 VEML6040::VEML6040(void) {


### PR DESCRIPTION
1) File is lowercase, include should be lowercase too (not all environments are case insensitive).
2) Compiling with ESP8266/32 gives an error: 

~/Arduino/libraries/VEML6040-master/src/veml6040.cpp: In member function 'uint16_t VEML6040::getCCT(float)':
~/Arduino/libraries/VEML6040-master/src/veml6040.cpp:125:34: error: 'pow' was not declared in this scope
   cct = 4278.6 * pow(ccti,-1.2455);

Can be fixed with a conditional include, I haven't tested this on the initial environment thought (only tried esp32, esp8266, arduino nano), probably worth more testing.